### PR TITLE
make user-nav more tap-friendly

### DIFF
--- a/src/legacy/components/user-nav/_user-nav.scss
+++ b/src/legacy/components/user-nav/_user-nav.scss
@@ -1,7 +1,7 @@
 .user-nav {
   background-color: var(--color-background-content);
   border-bottom-left-radius: 1em;
-  font-size: 0.75rem;
+  font-size: 0.9rem;
   padding: 0.75em 1.5em;
   position: absolute;
   right: 0;


### PR DESCRIPTION
## Overview

Slighting increasing the font size of user-nav from .75 to .9 makes it more tap-friendly on mobile devices.

## Screenshots

Before:

<img width="390" alt="Screenshot 2023-04-15 at 12 43 56 PM" src="https://user-images.githubusercontent.com/4856235/232250331-ef86a7bd-6614-44b6-813e-abb12d2bb3a1.png">
<img width="388" alt="Screenshot 2023-04-15 at 12 44 40 PM" src="https://user-images.githubusercontent.com/4856235/232250340-7d04119c-843f-4724-9a72-417b32e30990.png">

After:

<img width="388" alt="Screenshot 2023-04-15 at 12 44 21 PM" src="https://user-images.githubusercontent.com/4856235/232250342-9ab31045-0250-4f65-9eba-879695b45485.png">
<img width="388" alt="Screenshot 2023-04-15 at 12 44 58 PM" src="https://user-images.githubusercontent.com/4856235/232250347-bf7db91c-101a-4151-bf15-8d0f3517b68a.png">

## Testing

This is a simple CSS change, so not much testing is required besides noticing if the user nav links are larger than before. :)

---

- Fixes "hi! May I offer a small suggestion?  Moving the log in button.  It is sometimes difficut to click on when using a mobile device" requested at https://mltshpv2.slack.com/archives/C04HLRV3WS0/p1681497107357189
