### PR TITLE
Alt text

### DIFF
--- a/src/legacy/components/images/_images.scss
+++ b/src/legacy/components/images/_images.scss
@@ -6,6 +6,7 @@
 @use 'partials/image-content';
 @use 'partials/image-nsfw';
 @use 'partials/image-description';
+@use 'partials/image-alt-text';
 @use 'partials/image-interactions';
 @use 'partials/image-footer';
 @use 'partials/image-comments';

--- a/src/legacy/components/images/partials/_image-alt-text.scss
+++ b/src/legacy/components/images/partials/_image-alt-text.scss
@@ -42,8 +42,8 @@
   .alt-text-edit-form {
     display: none;
 
-    h3 {
-      margin-bottom: 5px;
+    .alt-text-learn {
+      margin-top: 5px;
     }
 
     textarea {

--- a/src/legacy/components/images/partials/_image-alt-text.scss
+++ b/src/legacy/components/images/partials/_image-alt-text.scss
@@ -1,0 +1,52 @@
+@use '../../../../base/links';
+@use '../../../../init/mixins';
+
+.image-content {
+  .alt-text {
+    color: var(--color-page-text);
+    font-size: 0.875rem;
+    overflow: hidden;
+    padding-bottom: var(--size-spacing-default);
+  }
+
+  .the-alt-text {
+    @include mixins.breakword;
+
+    &.the-alt-text-blank {
+      color: var(--color-status-disabled);
+      font-style: italic;
+    }
+  }
+
+  // Inline Editing Alt Text
+  .alt-text-edit .the-alt-text:hover,
+  .alt-text-edit .the-alt-text:focus,
+  .the-alt-text-hover {
+    background-color: var(--color-status-edit);
+  }
+
+  .alt-text-edit-form {
+    display: none;
+
+    textarea {
+      background-color: var(--color-background-content);
+      border: 1px solid var(--color-border-default);
+      border-radius: var(--size-border-radius-default);
+      color: var(--color-page-text);
+      min-height: 100px;
+      padding: var(--size-spacing-half);
+    }
+
+    .buttons {
+      display: flex;
+      padding: var(--size-spacing-default) 0;
+    }
+
+    .or {
+      color: var(--color-page-text-secondary);
+      display: block;
+      padding: var(--size-spacing-half) var(--size-spacing-default)
+        var(--size-spacing-half-again) var(--size-spacing-default);
+    }
+  }
+}

--- a/src/legacy/components/images/partials/_image-alt-text.scss
+++ b/src/legacy/components/images/partials/_image-alt-text.scss
@@ -10,6 +10,10 @@
 
     .the-alt-text {
       @include mixins.breakword;
+
+      &:focus {
+        box-shadow: none;
+      }
     }
 
     &.alt-text--blank .the-alt-text {
@@ -30,7 +34,6 @@
 
   // Inline Editing Alt Text
   .alt-text-edit .the-alt-text:hover,
-  .alt-text-edit .the-alt-text:focus,
   .the-alt-text-hover {
     background-color: var(--color-status-edit);
   }

--- a/src/legacy/components/images/partials/_image-alt-text.scss
+++ b/src/legacy/components/images/partials/_image-alt-text.scss
@@ -7,14 +7,24 @@
     font-size: 0.875rem;
     overflow: hidden;
     padding-bottom: var(--size-spacing-default);
-  }
 
-  .the-alt-text {
-    @include mixins.breakword;
+    .the-alt-text {
+      @include mixins.breakword;
+    }
 
-    &.the-alt-text-blank {
+    &.alt-text--blank .the-alt-text {
       color: var(--color-status-disabled);
       font-style: italic;
+    }
+
+    &.alt-text--blank .alt-text-toggle,
+    &.alt-text--editing .alt-text-toggle {
+      display: none;
+    }
+
+    &.alt-text--hidden .the-alt-text,
+    &.alt-text--editing .the-alt-text {
+      display: none;
     }
   }
 
@@ -25,8 +35,16 @@
     background-color: var(--color-status-edit);
   }
 
+  .alt-text--editing .alt-text-edit-form {
+    display: block;
+  }
+
   .alt-text-edit-form {
     display: none;
+
+    h3 {
+      margin-bottom: 5px;
+    }
 
     textarea {
       background-color: var(--color-background-content);
@@ -48,5 +66,9 @@
       padding: var(--size-spacing-half) var(--size-spacing-default)
         var(--size-spacing-half-again) var(--size-spacing-default);
     }
+  }
+
+  .alt-text-toggle {
+    cursor: pointer;
   }
 }

--- a/src/legacy/components/images/partials/_image-alt-text.scss
+++ b/src/legacy/components/images/partials/_image-alt-text.scss
@@ -33,6 +33,7 @@
   }
 
   // Inline Editing Alt Text
+  // stylelint-disable-next-line a11y/selector-pseudo-class-focus this element is not focusable
   .alt-text-edit .the-alt-text:hover,
   .the-alt-text-hover {
     background-color: var(--color-status-edit);

--- a/src/legacy/components/images/partials/_image-alt-text.scss
+++ b/src/legacy/components/images/partials/_image-alt-text.scss
@@ -33,7 +33,7 @@
   }
 
   // Inline Editing Alt Text
-  // stylelint-disable-next-line a11y/selector-pseudo-class-focus this element is not focusable
+  // stylelint-disable-next-line a11y/selector-pseudo-class-focus
   .alt-text-edit .the-alt-text:hover,
   .the-alt-text-hover {
     background-color: var(--color-status-edit);

--- a/src/legacy/components/images/partials/_image-alt-text.scss
+++ b/src/legacy/components/images/partials/_image-alt-text.scss
@@ -33,11 +33,12 @@
   }
 
   // Inline Editing Alt Text
-  // stylelint-disable-next-line a11y/selector-pseudo-class-focus
+  // stylelint-disable a11y/selector-pseudo-class-focus
   .alt-text-edit .the-alt-text:hover,
   .the-alt-text-hover {
     background-color: var(--color-status-edit);
   }
+  // stylelint-enable a11y/selector-pseudo-class-focus
 
   .alt-text--editing .alt-text-edit-form {
     display: block;

--- a/src/legacy/components/images/partials/_image-description.scss
+++ b/src/legacy/components/images/partials/_image-description.scss
@@ -32,6 +32,10 @@
   .description-edit-form {
     display: none;
 
+    h3 {
+      margin-bottom: 5px;
+    }
+
     textarea {
       background-color: var(--color-background-content);
       border: 1px solid var(--color-border-default);


### PR DESCRIPTION
## Overview

Front-end CSS for adding an alt text mechanism for images and videos on MLTSHP. It might make sense to consolidate discussion on the PR over on the mltshp repo: https://github.com/MLTSHP/mltshp/pull/710

## Screenshots

<img width="598" alt="A screengrab of an example teapot.jpg before alt text has been entered, light gray text says 'add alt text'." src="https://github.com/MLTSHP/mltshp/assets/38114/c6524902-945c-44a8-aefc-087c99b9fd99">
<img width="596" alt="A screengrab of the alt text editor, with a textarea input, save button, cancel button, and a link to learn more about alt text." src="https://github.com/MLTSHP/mltshp/assets/38114/3a12b1ec-c4d3-4ea9-9d97-ab181b2ca4fb">
<img width="559" alt="A screengrab showing the visual alt text toggle below the image." src="https://github.com/MLTSHP/mltshp/assets/38114/dc43350c-b12b-428b-8bbe-d01ecae4f63d">
