### PR TITLE
Run build:min on dist directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build:tokens": "node ./build-tokens.cjs",
     "build:scss": "sass --no-source-map src:.temp",
     "build:postcss": "postcss .temp/*.css -d dist",
-    "build:min": "postcss .temp/*.css -u cssnano -d dist --ext .min.css --no-map",
+    "build:min": "postcss dist/*.css -u cssnano -d dist --ext .min.css --no-map",
     "svgo": "svgo -r -f ./src/assets",
     "test": "yarn lint:check",
     "lint": "run-s lint:js lint:css lint:prettier",


### PR DESCRIPTION
## Overview

While working on #1024 I noticed that my `yarn build` was producing a `dist/main.min.css` file that didn't load the SVG data as intended (instead I would see `background-image: svg-load("balloons/comment-quip-left.svg")`). So I tried running `npx postcss .temp/*.css -d test` and inspected my test directory, and the files in there had the SVG data. Then I realized that the `build:min` step was overwriting the file from the `min:postcss` step.

This PR adjusts the `build:min` step so that it minifies the files produced by `build:postcss` saved in the `dist` directory.

## Screenshots

Before

<img width="387" alt="Screenshot 2023-06-29 at 9 16 58 PM" src="https://github.com/MLTSHP/mltshp-patterns/assets/38114/356ec367-d35d-43dd-b2fb-7f6dc63ed2cf">

After

<img width="368" alt="Screenshot 2023-06-29 at 9 17 20 PM" src="https://github.com/MLTSHP/mltshp-patterns/assets/38114/d8f4f638-922e-42be-8862-156681c84787">

