### PR TITLE
Make Alt Text Distinct from Description

### DIFF
--- a/src/legacy/components/images/examples/alt-text.html
+++ b/src/legacy/components/images/examples/alt-text.html
@@ -10,8 +10,15 @@
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">
-      <div class="alt-text alt-text--hidden">
+      <div class="alt-text">
         <div class="alt-text-toggle link link--primary">alt text</div>
+        <div class="the-alt-text" role="button" tabindex="0">
+          Photo of a happy-looking dog wearing safety glasses, pouring from a
+          flask labelled "Danger" into a coffee mug, while surrounded by
+          chemistry equipment such as bunsen burners and containers of bubbling
+          fluids connected by tubes. The caption reads "I have no idea what I'm
+          doing."
+        </div>
       </div>
       <div class="description">
         <div class="the-description">

--- a/src/legacy/components/images/examples/editable.html
+++ b/src/legacy/components/images/examples/editable.html
@@ -23,6 +23,9 @@
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">
+      <div class="alt-text alt-text-edit alt-text--blank">
+        <div class="the-alt-text" role="button">add some alt text</div>
+      </div>
       <div class="description description-edit">
         <div class="the-description the-description-blank">
           click here to edit description

--- a/src/legacy/components/images/examples/editing.html
+++ b/src/legacy/components/images/examples/editing.html
@@ -25,6 +25,40 @@
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">
+      <div class="alt-text alt-text-edit alt-text--blank alt-text--editing">
+        <div class="alt-text-toggle link link--primary">alt text</div>
+        <div class="the-alt-text" role="button">add some alt text</div>
+        <form
+          method="post"
+          class="alt-text-edit-form"
+          action="/p/1OWRQ/quick-edit-alt-text"
+        >
+          <input
+            type="hidden"
+            name="_xsrf"
+            value="2|373c3cd0|287dcfa53f2ba090a42ed6c296c0da34|1687810733"
+          />
+          <h3>Edit alt text</h3>
+          <p class="alt-text-learn">
+            Alt text describes images for blind and low-vision users, and helps
+            give context to everyone. <a href="/faq/#alt-text">Learn more</a>.
+          </p>
+          <textarea
+            name="alt_text"
+            class="alt-text-edit-textarea"
+            tabindex="0"
+          ></textarea>
+          <div class="buttons">
+            <input
+              type="submit"
+              class="save btn btn-primary btn-small"
+              value="Save"
+            />
+            <span class="or">or</span>
+            <a href="" class="cancel btn btn-secondary btn-small">Cancel</a>
+          </div>
+        </form>
+      </div>
       <div class="description description-edit">
         <div class="the-description" style="display: none">
           Star Wars is jumping on the Zoom background train. I’m looking forward
@@ -39,6 +73,7 @@
           >
         </div>
         <form class="description-edit-form" style="display: block">
+          <h3>Edit description</h3>
           <textarea name="description" class="description-edit-textarea">
 Star Wars is jumping on the Zoom background train. I’m looking forward to showing how clean I’ve kept my office with this one.
 

--- a/src/legacy/components/images/images.stories.js
+++ b/src/legacy/components/images/images.stories.js
@@ -1,4 +1,5 @@
 import permalinkMarkup from './examples/permalink.html?raw';
+import altTextMarkup from './examples/alt-text.html?raw';
 import listMarkup from './examples/list.html?raw';
 import commentsMarkup from './examples/comments.html?raw';
 import commentingMarkup from './examples/commenting.html?raw';
@@ -33,6 +34,10 @@ export default {
 
 export const Permalink = {
   render: () => permalinkMarkup,
+};
+
+export const AltText = {
+  render: () => altTextMarkup,
 };
 
 export const ListView = {

--- a/src/legacy/components/images/partials/_image-alt-text.scss
+++ b/src/legacy/components/images/partials/_image-alt-text.scss
@@ -10,6 +10,10 @@
 
     .the-alt-text {
       @include mixins.breakword;
+      background: var(--color-background-content-secondary);
+      color: var(--color-page-text-secondary);
+      margin-top: var(--size-spacing-half);
+      padding: var(--size-spacing-default) var(--size-spacing-half-again);
 
       &:focus {
         box-shadow: none;


### PR DESCRIPTION
## Overview

This PR updates the styles for the alt text to be more visually distinct from the description.

## Screenshots

<img width="400" alt="Screenshot 2023-07-01 at 1 22 37 PM" src="https://github.com/MLTSHP/mltshp-patterns/assets/257309/a51a6d5f-7e3f-450e-95a7-ea8ae46c9a67">

## Testing

1. On the [deploy preview](https://deploy-preview-1027--mltshp-patterns.netlify.app/), Review the Legacy / Components / Image / Alt Text story, and confirm the alt text is visually distinct from the description.