### PR TITLE
Picker alt text

### DIFF
--- a/src/legacy/areas/picker/_picker.scss
+++ b/src/legacy/areas/picker/_picker.scss
@@ -92,7 +92,7 @@
       font-weight: var(--number-font-weight-bold);
     }
 
-    .field + .field {
+    .field-textarea + .field-textarea {
       margin-top: 0;
     }
 

--- a/src/legacy/areas/picker/_picker.scss
+++ b/src/legacy/areas/picker/_picker.scss
@@ -91,6 +91,59 @@
     .tools-field-title .input-text {
       font-weight: var(--number-font-weight-bold);
     }
+
+    .field + .field {
+      margin-top: 0;
+    }
+
+    .field-textarea {
+      height: 0;
+      overflow: hidden;
+
+      &.field-textarea--selected {
+        height: auto;
+      }
+    }
+
+    .textarea-navigation {
+      ul {
+        display: flex;
+        list-style: none;
+        margin: 0;
+        padding: var(--size-spacing-half-again);
+        padding-bottom: 0;
+
+        @media screen and (min-width: tokens.$size-breakpoint-md) {
+          padding-left: var(--size-spacing-double);
+        }
+      }
+
+      li + li {
+        @media screen and (min-width: tokens.$size-breakpoint-md) {
+          margin-left: var(--size-spacing-half-again);
+        }
+      }
+
+      .tab {
+        border-top-left-radius: var(--size-border-radius-default);
+        border-top-right-radius: var(--size-border-radius-default);
+        display: block;
+        font-size: 0.875rem;
+        padding: var(--size-spacing-default);
+        cursor: pointer;
+      }
+
+      @media (hover) {
+        .tab:hover {
+          background-color: var(--color-form-bg);
+        }
+      }
+
+      .selected .tab {
+        font-weight: bold;
+        background-color: var(--color-border-form);
+      }
+    }
   }
 
   //

--- a/src/legacy/areas/picker/_picker.scss
+++ b/src/legacy/areas/picker/_picker.scss
@@ -127,21 +127,22 @@
       .tab {
         border-top-left-radius: var(--size-border-radius-default);
         border-top-right-radius: var(--size-border-radius-default);
+        cursor: pointer;
         display: block;
         font-size: 0.875rem;
         padding: var(--size-spacing-default);
-        cursor: pointer;
       }
 
       @media (hover) {
-        .tab:hover {
+        .tab:hover,
+        .tab:focus {
           background-color: var(--color-form-bg);
         }
       }
 
       .selected .tab {
-        font-weight: bold;
         background-color: var(--color-border-form);
+        font-weight: bold;
       }
     }
   }

--- a/src/legacy/areas/picker/_picker.scss
+++ b/src/legacy/areas/picker/_picker.scss
@@ -133,11 +133,9 @@
         padding: var(--size-spacing-default);
       }
 
-      @media (hover) {
-        .tab:hover,
-        .tab:focus {
-          background-color: var(--color-form-bg);
-        }
+      .tab:hover,
+      .tab:focus {
+        background-color: var(--color-form-bg);
       }
 
       .selected .tab {


### PR DESCRIPTION
__Note:__ it might make sense to consolidate discussion over on the `mltshp` repo: https://github.com/MLTSHP/mltshp/pull/723

## Overview

This adds an interface for specifying alt text from the "picker" template, used by browser extensions and bookmarklets to upload to the site. The tabbed interface is modeled on the one from Settings. Fixes https://github.com/MLTSHP/mltshp/issues/719

## Screenshots

<img width="725" alt="New post interface showing title field, and a tabbed interface where the Description tab is selected and Alt Text tab is not selected, a textarea field is below with the text 'source: https://example.com'. A piggy bank Save This button is below." src="https://github.com/MLTSHP/mltshp/assets/38114/93a8d772-ea4f-4d4c-8e5c-6ab9ca68d1fe">
<img width="727" alt="New post interface showing title field, and a tabbed interface where the Alt Text tab is selected and Description tab is not selected, a textarea field is below with the text 'alt text goes here'. A piggy bank Save This button is below." src="https://github.com/MLTSHP/mltshp/assets/38114/a299620d-6355-4baa-aee8-3121ae54d747">