### PR TITLE
Permalink Layout for Content

### DIFF
--- a/src/legacy/areas/permalink/_permalink.scss
+++ b/src/legacy/areas/permalink/_permalink.scss
@@ -30,7 +30,7 @@
   > .permalink-sidebar {
     @media screen and (min-width: tokens.$size-breakpoint-lg) {
       float: right;
-      width: 330px;
+      width: 320px;
     }
   }
 
@@ -39,7 +39,7 @@
   > .image-comment-form {
     @media screen and (min-width: tokens.$size-breakpoint-lg) {
       float: left;
-      width: calc(100% - 360px);
+      width: calc(100% - 350px);
     }
   }
 }
@@ -47,7 +47,7 @@
 //
 // Fancy new grid-based layout
 //
-@supports (display: grid) {
+@supports (display: xxxxgrid) {
   @media screen and (min-width: tokens.$size-breakpoint-lg) {
     .content-permalink {
       display: grid;
@@ -57,7 +57,7 @@
         'image sidebar'
         'comments sidebar'
         'post-comment sidebar';
-      grid-template-columns: 1fr 330px;
+      grid-template-columns: 1fr 320px;
       // stylelint-disable-next-line declaration-block-no-redundant-longhand-properties
       grid-template-rows: repeat(3, min-content) 1fr;
     }

--- a/src/legacy/areas/permalink/_permalink.scss
+++ b/src/legacy/areas/permalink/_permalink.scss
@@ -47,7 +47,7 @@
 //
 // Fancy new grid-based layout
 //
-@supports (display: xxxxgrid) {
+@supports (display: grid) {
   @media screen and (min-width: tokens.$size-breakpoint-lg) {
     .content-permalink {
       display: grid;


### PR DESCRIPTION
## Overview

This PR adjusts the layout of the permalink page from the previous:

```
total = content + gutter + sidebar
900   = 540     + 30     + 330
```

To the updated:

```
total = content + gutter + sidebar
900   = 550     + 30     + 320
```

This better reflects our image intrinsic width of 550 from the CDN.

## Screenshots

<img width="996" alt="Screenshot 2024-12-29 at 11 49 32 AM" src="https://github.com/user-attachments/assets/e7ad8a37-1e2b-4b09-9929-d31736fc86a1" />

## Testing

- [ ] Review [the Permalink page on the preview deploy](https://deploy-preview-1279--mltshp-patterns.netlify.app/?path=/story/legacy-areas-permalink--permalink) at various viewport sizes and ensure there are no regressions.

---

- Fixes #1278
