### PR TITLE
Shake Layout for Content

### DIFF
--- a/src/legacy/layout/_page.scss
+++ b/src/legacy/layout/_page.scss
@@ -79,7 +79,6 @@
 
   .body {
     flex: 1;
-    padding-right: 1px; // dumb, but needed to keep from collapsing -SV
   }
 
   .sidebar {
@@ -99,7 +98,7 @@
         var(--color-base-white-transparent) calc(100% - 6px),
         var(--color-border-default)
       );
-      flex: 0 0 325px;
+      flex: 0 0 330px;
       order: 0;
     }
   }


### PR DESCRIPTION
## Overview

This PR adjusts the layout of the shake page from the previous:

```
total = sidebar + pad + content + pad
960   = 325     + 40  + 555     + 40
```

To the updated:

```
total = sidebar + pad + content + pad
960   = 330     + 40  + 550     + 40
```

This better reflects our image intrinsic width of 550 from the CDN.

## Testing

- [x] Review [the shake page](https://deploy-preview-1301--mltshp-patterns.netlify.app/iframe.html?args=&id=legacy-areas-shake--shake&viewMode=story) at various viewport sizes and ensure there are no regressions.

---

- Fixes #1280