### PR TITLE
Bugfix: Shake Invite Form Stacking

### DIFF
--- a/src/legacy/areas/shake/examples/shake.html
+++ b/src/legacy/areas/shake/examples/shake.html
@@ -57,7 +57,78 @@
                 >
                   Invite
                 </button>
-                <ul class="shake-results"></ul>
+                <ul class="shake-results">
+                  <li>
+                    <img
+                      src="//mltshp-cdn.com/static/images/default-icon-venti.svg"
+                      width="24"
+                      height="24"
+                    /><span>A124D520034</span>
+                  </li>
+                  <li>
+                    <img
+                      src="//mltshp-cdn.com/s3/account/101519/profile.jpg"
+                      width="24"
+                      height="24"
+                    /><span>A420N</span>
+                  </li>
+                  <li>
+                    <img
+                      src="//mltshp-cdn.com/static/images/default-icon-venti.svg"
+                      width="24"
+                      height="24"
+                    /><span>A4Awesome</span>
+                  </li>
+                  <li>
+                    <img
+                      src="//mltshp-cdn.com/s3/account/1529/profile.jpg"
+                      width="24"
+                      height="24"
+                    /><span>aa</span>
+                  </li>
+                  <li>
+                    <img
+                      src="//mltshp-cdn.com/static/images/default-icon-venti.svg"
+                      width="24"
+                      height="24"
+                    /><span>Aarondap</span>
+                  </li>
+                  <li>
+                    <img
+                      src="//mltshp-cdn.com/static/images/default-icon-venti.svg"
+                      width="24"
+                      height="24"
+                    /><span>AaronHal</span>
+                  </li>
+                  <li>
+                    <img
+                      src="//mltshp-cdn.com/s3/account/101201/profile.jpg"
+                      width="24"
+                      height="24"
+                    /><span>aaronschmidt</span>
+                  </li>
+                  <li>
+                    <img
+                      src="//mltshp-cdn.com/static/images/default-icon-venti.svg"
+                      width="24"
+                      height="24"
+                    /><span>Aaronsulky</span>
+                  </li>
+                  <li>
+                    <img
+                      src="//mltshp-cdn.com/static/images/default-icon-venti.svg"
+                      width="24"
+                      height="24"
+                    /><span>Abandonedbalt</span>
+                  </li>
+                  <li>
+                    <img
+                      src="//mltshp-cdn.com/static/images/default-icon-venti.svg"
+                      width="24"
+                      height="24"
+                    /><span>AbandonedBycle</span>
+                  </li>
+                </ul>
               </div>
             </form>
           </div>

--- a/src/legacy/components/sidebar/_sidebar.scss
+++ b/src/legacy/components/sidebar/_sidebar.scss
@@ -260,6 +260,7 @@
     display: flex;
     padding: var(--size-spacing-half);
     position: relative;
+    z-index: 1;
   }
 
   .input-text {


### PR DESCRIPTION
## Overview

This PR fixes a bug where the dropdown menu for the "Invite a New Member" form on the Shake page appeared under the Search input.

## Screenshots

**Old:**
<img width="307" alt="232867284-e9a91622-b1f2-4b9e-bfa8-71128c1f6ca2" src="https://github.com/user-attachments/assets/46be01a8-af76-4a2d-9590-b81d50702524" />

**New:**

## Testing

- [ ] Go to the Shake page on the preview deploy
- [ ] Inspect the "Invite a New Member" input in your browser's devtools
- [ ] You should see a sibling element: `<ul class="shake-results">` which is hidden.
- [ ] Add `display:block` to the shake results element.
- [ ] The shake results menu should appear on top of the search input.

---

- Fixes #980
