### PR TITLE
Fix Broken Image Links

### DIFF
--- a/src/base/examples/figures.html
+++ b/src/base/examples/figures.html
@@ -1,6 +1,6 @@
 <p>Figures are usually used to refer to images:</p>
 <figure>
-  <img alt="" src="https://source.unsplash.com/1280x720/daily?dogs" />
+  <img alt="" src="https://mltshp-cdn.com/r/1PJ8Z?width=550&dpr=2" />
   <figcaption>
     <h4>Figure Heading</h4>
     <p>This is a placeholder image, with supporting caption.</p>

--- a/src/base/examples/images.html
+++ b/src/base/examples/images.html
@@ -4,7 +4,10 @@
   tempor incididunt ut labore et dolore.
 </p>
 <p>
-  <img src="https://s.mltshp.com/r/1OWNY?width=550&dpr=2.5" alt="Test Image" />
+  <img
+    src="https://mltshp-cdn.com/r/1OWNY?width=550&dpr=2.5"
+    alt="Test Image"
+  />
 </p>
 <p>
   Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
@@ -18,7 +21,7 @@
 </p>
 <p>
   <img
-    src="https://s.mltshp.com/r/1ND3N?width=340&dpr=1"
+    src="https://mltshp-cdn.com/r/1ND3N?width=340&dpr=1"
     alt="Small Test Image"
   />
 </p>

--- a/src/base/examples/images.html
+++ b/src/base/examples/images.html
@@ -4,10 +4,7 @@
   tempor incididunt ut labore et dolore.
 </p>
 <p>
-  <img
-    src="https://source.unsplash.com/1920x1080/daily?cats"
-    alt="Test Image"
-  />
+  <img src="https://s.mltshp.com/r/1OWNY?width=550&dpr=2.5" alt="Test Image" />
 </p>
 <p>
   Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
@@ -21,7 +18,7 @@
 </p>
 <p>
   <img
-    src="https://source.unsplash.com/320x180/daily?dogs"
+    src="https://s.mltshp.com/r/1ND3N?width=340&dpr=1"
     alt="Small Test Image"
   />
 </p>

--- a/src/legacy/areas/incoming/examples/incoming.html
+++ b/src/legacy/areas/incoming/examples/incoming.html
@@ -59,7 +59,7 @@
             <div class="the-image">
               <a href="#"
                 ><img
-                  src="//s.mltshp.com/r/1JPNB"
+                  src="//mltshp-cdn.com/r/1JPNB"
                   alt="Beijing's skyline taken from the Great Wall of China"
               /></a>
             </div>
@@ -180,7 +180,7 @@
             <div class="the-image">
               <a href="#"
                 ><img
-                  src="//s.mltshp.com/r/1IGIU"
+                  src="//mltshp-cdn.com/r/1IGIU"
                   alt="Star Wars Zoom Backgrounds"
               /></a>
             </div>

--- a/src/legacy/areas/permalink/examples/lengthy.html
+++ b/src/legacy/areas/permalink/examples/lengthy.html
@@ -9,7 +9,7 @@
         <div class="the-image">
           <a href="#"
             ><img
-              src="//s.mltshp.com/r/1BG3N"
+              src="//mltshp-cdn.com/r/1BG3N"
               alt="Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch"
           /></a>
         </div>

--- a/src/legacy/areas/permalink/examples/permalink.html
+++ b/src/legacy/areas/permalink/examples/permalink.html
@@ -9,7 +9,7 @@
         <div class="the-image">
           <a href="#"
             ><img
-              src="//s.mltshp.com/r/1JQL0"
+              src="//mltshp-cdn.com/r/1JQL0"
               alt="For When The Coroner Arrives"
           /></a>
         </div>

--- a/src/legacy/areas/search/examples/search-results.html
+++ b/src/legacy/areas/search/examples/search-results.html
@@ -54,7 +54,7 @@
               <div class="the-image">
                 <a href="#"
                   ><img
-                    src="//s.mltshp.com/r/1ITQ8"
+                    src="//mltshp-cdn.com/r/1ITQ8"
                     alt="Panel from Barbarella by Jean-Claude Forest"
                 /></a>
               </div>
@@ -220,7 +220,7 @@
               <div class="the-image">
                 <a href="#"
                   ><img
-                    src="//s.mltshp.com/r/1H6VK"
+                    src="//mltshp-cdn.com/r/1H6VK"
                     alt='Miss Piggy And Kermit in Roger Vadim’s "Barbarella"'
                 /></a>
               </div>
@@ -323,7 +323,7 @@
               <div class="the-image">
                 <a href="#"
                   ><img
-                    src="//s.mltshp.com/r/10HZE"
+                    src="//mltshp-cdn.com/r/10HZE"
                     alt="Electric Barbarella (Myka Dunkle)"
                 /></a>
               </div>

--- a/src/legacy/areas/shake/examples/shake.html
+++ b/src/legacy/areas/shake/examples/shake.html
@@ -591,7 +591,9 @@
           </div>
           <div class="image-content">
             <div class="the-image">
-              <a href="#"><img src="//s.mltshp.com/r/1JPTU" alt="Fremen" /></a>
+              <a href="#"
+                ><img src="//mltshp-cdn.com/r/1JPTU" alt="Fremen"
+              /></a>
             </div>
             <div id="image-content-footer-1JPTU" class="image-content-footer">
               <div class="description">
@@ -715,7 +717,7 @@
           <div class="image-content">
             <div class="the-image">
               <a href="#"
-                ><img src="//s.mltshp.com/r/1JJ4N" alt="dune 1984 bts"
+                ><img src="//mltshp-cdn.com/r/1JJ4N" alt="dune 1984 bts"
               /></a>
             </div>
             <div id="image-content-footer-1JJ4N" class="image-content-footer">
@@ -820,7 +822,7 @@
           </div>
           <div class="image-content">
             <div class="the-image">
-              <a href="#"><img src="//s.mltshp.com/r/1JJ4M" alt="WAP" /></a>
+              <a href="#"><img src="//mltshp-cdn.com/r/1JJ4M" alt="WAP" /></a>
             </div>
             <div id="image-content-footer-1JJ4M" class="image-content-footer">
               <div class="description description-edit">

--- a/src/legacy/components/conversations/examples/conversation.html
+++ b/src/legacy/components/conversations/examples/conversation.html
@@ -1,14 +1,12 @@
 <div class="conversation">
   <a class="thumb" href="/p/1IFD4">
-    <img src="https://source.unsplash.com/100x56/daily?dogs" />
+    <img src="https://mltshp-cdn.com/r/1QE6J?width=100" />
   </a>
   <div class="details-wrapper">
-    <h3 class="sharedfile-title">Bootstraping</h3>
+    <h3 class="sharedfile-title">Don't Quit</h3>
     <p class="sharedfile-description">
-      source: the redditz:
-      <a href="#" target="_blank" rel="nofollow"
-        >https://mobile.twitter.com/shaun_vids</a
-      >
+      source:
+      <a href="#" target="_blank" rel="nofollow">https://example.com</a>
     </p>
     <div class="image-comments">
       <div class="comment">

--- a/src/legacy/components/image-medium/examples/image-medium.html
+++ b/src/legacy/components/image-medium/examples/image-medium.html
@@ -2,7 +2,7 @@
   <div class="image-medium-thumb">
     <a href="#"
       ><img
-        src="https://source.unsplash.com/100x56/daily?dogs"
+        src="https://mltshp-cdn.com/r/1QE6J?width=100"
         height="67"
         width="100"
         alt=""
@@ -18,7 +18,7 @@
         height="20"
       />
     </a>
-    <div class="title">Ferrari</div>
+    <div class="title">Don't Quit</div>
   </div>
   <ul class="stats">
     <li class="views">52 views</li>

--- a/src/legacy/components/images/examples/alt-text.html
+++ b/src/legacy/components/images/examples/alt-text.html
@@ -6,7 +6,7 @@
   <div class="image-content">
     <div class="the-image">
       <a href="#"
-        ><img src="//s.mltshp.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
+        ><img src="//mltshp-cdn.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">

--- a/src/legacy/components/images/examples/commenting.html
+++ b/src/legacy/components/images/examples/commenting.html
@@ -27,7 +27,7 @@
   <div class="image-content">
     <div class="the-image">
       <a href="#"
-        ><img src="//s.mltshp.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
+        ><img src="//mltshp-cdn.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">

--- a/src/legacy/components/images/examples/comments.html
+++ b/src/legacy/components/images/examples/comments.html
@@ -27,7 +27,7 @@
   <div class="image-content">
     <div class="the-image">
       <a href="#"
-        ><img src="//s.mltshp.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
+        ><img src="//mltshp-cdn.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">

--- a/src/legacy/components/images/examples/editable.html
+++ b/src/legacy/components/images/examples/editable.html
@@ -19,7 +19,7 @@
   <div class="image-content">
     <div class="the-image">
       <a href="#"
-        ><img src="//s.mltshp.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
+        ><img src="//mltshp-cdn.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">

--- a/src/legacy/components/images/examples/editing.html
+++ b/src/legacy/components/images/examples/editing.html
@@ -21,7 +21,7 @@
   <div class="image-content">
     <div class="the-image">
       <a href="#"
-        ><img src="//s.mltshp.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
+        ><img src="//mltshp-cdn.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">

--- a/src/legacy/components/images/examples/lengthy.html
+++ b/src/legacy/components/images/examples/lengthy.html
@@ -17,7 +17,7 @@
     <div class="the-image">
       <a href="#"
         ><img
-          src="//s.mltshp.com/r/1BG3N"
+          src="//mltshp-cdn.com/r/1BG3N"
           alt="Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch"
       /></a>
     </div>

--- a/src/legacy/components/images/examples/likes.html
+++ b/src/legacy/components/images/examples/likes.html
@@ -27,7 +27,7 @@
   <div class="image-content">
     <div class="the-image">
       <a href="#"
-        ><img src="//s.mltshp.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
+        ><img src="//mltshp-cdn.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">

--- a/src/legacy/components/images/examples/list-liked-saved.html
+++ b/src/legacy/components/images/examples/list-liked-saved.html
@@ -27,7 +27,7 @@
   <div class="image-content">
     <div class="the-image">
       <a href="#"
-        ><img src="//s.mltshp.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
+        ><img src="//mltshp-cdn.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">

--- a/src/legacy/components/images/examples/list-save-shake.html
+++ b/src/legacy/components/images/examples/list-save-shake.html
@@ -27,7 +27,7 @@
   <div class="image-content">
     <div class="the-image">
       <a href="#"
-        ><img src="//s.mltshp.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
+        ><img src="//mltshp-cdn.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">

--- a/src/legacy/components/images/examples/list.html
+++ b/src/legacy/components/images/examples/list.html
@@ -27,7 +27,7 @@
   <div class="image-content">
     <div class="the-image">
       <a href="#"
-        ><img src="//s.mltshp.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
+        ><img src="//mltshp-cdn.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">

--- a/src/legacy/components/images/examples/no-comments.html
+++ b/src/legacy/components/images/examples/no-comments.html
@@ -27,7 +27,7 @@
   <div class="image-content">
     <div class="the-image">
       <a href="#"
-        ><img src="//s.mltshp.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
+        ><img src="//mltshp-cdn.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">

--- a/src/legacy/components/images/examples/permalink.html
+++ b/src/legacy/components/images/examples/permalink.html
@@ -6,7 +6,7 @@
   <div class="image-content">
     <div class="the-image">
       <a href="#"
-        ><img src="//s.mltshp.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
+        ><img src="//mltshp-cdn.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">

--- a/src/legacy/components/images/examples/repost.html
+++ b/src/legacy/components/images/examples/repost.html
@@ -27,7 +27,7 @@
   <div class="image-content">
     <div class="the-image">
       <a href="#"
-        ><img src="//s.mltshp.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
+        ><img src="//mltshp-cdn.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">

--- a/src/legacy/components/images/examples/saves.html
+++ b/src/legacy/components/images/examples/saves.html
@@ -27,7 +27,7 @@
   <div class="image-content">
     <div class="the-image">
       <a href="#"
-        ><img src="//s.mltshp.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
+        ><img src="//mltshp-cdn.com/r/1IGIU" alt="Star Wars Zoom Backgrounds"
       /></a>
     </div>
     <div id="image-content-footer-1IGIU" class="image-content-footer">

--- a/src/legacy/components/new-users/examples/new-users.html
+++ b/src/legacy/components/new-users/examples/new-users.html
@@ -40,7 +40,7 @@
     <div class="image-medium">
       <div class="image-medium-thumb">
         <a href="#"
-          ><img src="https://source.unsplash.com/100x56/daily?dogs" alt=""
+          ><img src="https://mltshp-cdn.com/r/1QE6J?width=100" alt=""
         /></a>
       </div>
       <div class="user-and-title">
@@ -104,7 +104,7 @@
     <div class="image-medium">
       <div class="image-medium-thumb">
         <a href="#"
-          ><img src="https://source.unsplash.com/100x56/daily?cats" alt=""
+          ><img src="https://mltshp-cdn.com/r/1Q7DY?width=100" alt=""
         /></a>
       </div>
       <div class="user-and-title">
@@ -168,7 +168,7 @@
     <div class="image-medium">
       <div class="image-medium-thumb">
         <a href="#"
-          ><img src="https://source.unsplash.com/100x56/daily?goats" alt=""
+          ><img src="https://mltshp-cdn.com/r/1QB81?width=100" alt=""
         /></a>
       </div>
       <div class="user-and-title">

--- a/src/legacy/components/notifications/examples/notification-comment.html
+++ b/src/legacy/components/notifications/examples/notification-comment.html
@@ -3,9 +3,7 @@
   <div class="notification-block-bd" style="display: block">
     <div class="notification">
       <div class="thumb">
-        <a href="#"
-          ><img src="https://source.unsplash.com/100x56/daily?dogs"
-        /></a>
+        <a href="#"><img src="https://mltshp-cdn.com/r/1Q7DY?width=100" /></a>
       </div>
       <div class="context">
         <a href="#">Bob Dobbs</a>
@@ -16,9 +14,7 @@
     </div>
     <div class="notification">
       <div class="thumb">
-        <a href="#"
-          ><img src="https://source.unsplash.com/100x56/daily?cats"
-        /></a>
+        <a href="#"><img src="https://mltshp-cdn.com/r/1QE6J?width=100" /></a>
       </div>
       <div class="context">
         <a href="#">Captain America</a>

--- a/src/legacy/components/notifications/examples/notification-like.html
+++ b/src/legacy/components/notifications/examples/notification-like.html
@@ -3,9 +3,7 @@
   <div class="notification-block-bd" style="display: block">
     <div class="notification">
       <div class="thumb">
-        <a href="#"
-          ><img src="https://source.unsplash.com/100x56/daily?dogs"
-        /></a>
+        <a href="#"><img src="https://mltshp-cdn.com/r/1Q7DY?width=100" /></a>
       </div>
       <div class="context">
         <a href="#">Ferrari</a>
@@ -14,9 +12,7 @@
     </div>
     <div class="notification">
       <div class="thumb">
-        <a href="#"
-          ><img src="https://source.unsplash.com/100x56/daily?cats"
-        /></a>
+        <a href="#"><img src="https://mltshp-cdn.com/r/1QE6J?width=100" /></a>
       </div>
       <div class="context">
         <a href="#">Moar Ferraris</a>

--- a/src/legacy/components/notifications/examples/notification-save.html
+++ b/src/legacy/components/notifications/examples/notification-save.html
@@ -3,9 +3,7 @@
   <div class="notification-block-bd" style="display: block">
     <div class="notification">
       <div class="thumb">
-        <a href="#"
-          ><img src="https://source.unsplash.com/100x56/daily?dogs"
-        /></a>
+        <a href="#"><img src="https://mltshp-cdn.com/r/1Q7DY?width=100" /></a>
       </div>
       <div class="context">
         <a href="#">Ferrari</a>
@@ -14,9 +12,7 @@
     </div>
     <div class="notification">
       <div class="thumb">
-        <a href="#"
-          ><img src="https://source.unsplash.com/100x56/daily?cats"
-        /></a>
+        <a href="#"><img src="https://mltshp-cdn.com/r/1QE6J?width=100" /></a>
       </div>
       <div class="context">
         <a href="#">Moar Ferraris</a>

--- a/src/legacy/components/site-header/examples/logged-in-with-content.html
+++ b/src/legacy/components/site-header/examples/logged-in-with-content.html
@@ -632,7 +632,9 @@
           </div>
           <div class="image-content">
             <div class="the-image">
-              <a href="#"><img src="//s.mltshp.com/r/1JPTU" alt="Fremen" /></a>
+              <a href="#"
+                ><img src="//mltshp-cdn.com/r/1JPTU" alt="Fremen"
+              /></a>
             </div>
             <div id="image-content-footer-1JPTU" class="image-content-footer">
               <div class="description">
@@ -756,7 +758,7 @@
           <div class="image-content">
             <div class="the-image">
               <a href="#"
-                ><img src="//s.mltshp.com/r/1JJ4N" alt="dune 1984 bts"
+                ><img src="//mltshp-cdn.com/r/1JJ4N" alt="dune 1984 bts"
               /></a>
             </div>
             <div id="image-content-footer-1JJ4N" class="image-content-footer">
@@ -861,7 +863,7 @@
           </div>
           <div class="image-content">
             <div class="the-image">
-              <a href="#"><img src="//s.mltshp.com/r/1JJ4M" alt="WAP" /></a>
+              <a href="#"><img src="//mltshp-cdn.com/r/1JJ4M" alt="WAP" /></a>
             </div>
             <div id="image-content-footer-1JJ4M" class="image-content-footer">
               <div class="description description-edit">


### PR DESCRIPTION
## Overview

Some example images were using the now-sunset Unsplash image API. This replaces those images with ones from our own site.

## Testing

The following pages on the preview deploy should not contain broken images:

- [ ] Base -> Media -> Figures
- [ ] Base -> Media -> Images
- [ ] Legacy ->Components -> Conversation
- [ ] Legacy ->Components -> Image Medium
- [ ] Legacy -> Components -> New Users
- [ ] Legacy -> Components -> Notifications -> Saves
- [ ] Legacy -> Components -> Notifications -> Likes
- [ ] Legacy -> Components -> Notifications -> Comments

---

- Fixes #1304
