### PR TITLE
Fix Sass Deprecation Warnings

### DIFF
--- a/src/legacy/areas/incoming/_incoming.scss
+++ b/src/legacy/areas/incoming/_incoming.scss
@@ -26,9 +26,14 @@
 
 .incoming-header {
   @include page-header.page-header;
-  cursor: pointer;
-  padding: var(--size-spacing-half-again) var(--size-spacing-double);
-  width: 100%;
+
+  // @see https://sass-lang.com/documentation/breaking-changes/mixed-decls/
+  // stylelint-disable-next-line no-duplicate-selectors, scss/selector-no-redundant-nesting-selector
+  & {
+    cursor: pointer;
+    padding: var(--size-spacing-half-again) var(--size-spacing-double);
+    width: 100%;
+  }
 
   @media screen and (min-width: tokens.$size-breakpoint-lg) {
     align-items: center;

--- a/src/legacy/areas/settings/_settings.scss
+++ b/src/legacy/areas/settings/_settings.scss
@@ -7,10 +7,15 @@
 //
 .settings-header {
   @include page-header.page-header;
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+
+  // @see https://sass-lang.com/documentation/breaking-changes/mixed-decls/
+  // stylelint-disable-next-line no-duplicate-selectors, scss/selector-no-redundant-nesting-selector
+  & {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
 
   @media screen and (min-width: tokens.$size-breakpoint-lg) {
     flex-direction: row;


### PR DESCRIPTION
## Overview

Sass is changing the way nested rules work to better match native CSS nesting, and it's complaining about a couple spots in our code. This PR fixes the problem using the Sass team's recommended solution.

## Testing

Review the "build" action on this PR — you should not see any Sass deprecation warnings (compare to the last build action run on the main branch).

---

- Fixes #1322
