### PR TITLE
Compact Peekaboo Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Shake Invite Form Stacking (#1326)
-- Shake Invite Form Dark Mode (#1325)
-- Firefox Shake Invite Button Layout (#1323)
-- Adjusting z-index for site header
+- Compact Peekaboo Header (#1331)
+- Bugfix: Shake Invite Form Stacking (#1326)
+- Bugfix: Shake Invite Form Dark Mode (#1325)
+- Bugfix: Firefox Shake Invite Button Layout (#1323)
+- Bugfix: Adjusting z-index for site header (#1321)
 
 ## [2.8.0] - 2025-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Compact Peekaboo Header (#1331)
-    - Breaking change: You'll need to change `site-branding--icon` from a `<span>`
-      element to a `<div>` element.
+  - Breaking change: You'll need to change `site-branding--icon` from a `<span>`
+    element to a `<div>` element.
 - Bugfix: Shake Invite Form Stacking (#1326)
 - Bugfix: Shake Invite Form Dark Mode (#1325)
 - Bugfix: Firefox Shake Invite Button Layout (#1323)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Compact Peekaboo Header (#1331)
+    - Breaking change: You'll need to change `site-branding--icon` from a `<span>`
+      element to a `<div>` element.
 - Bugfix: Shake Invite Form Stacking (#1326)
 - Bugfix: Shake Invite Form Dark Mode (#1325)
 - Bugfix: Firefox Shake Invite Button Layout (#1323)

--- a/src/legacy/components/site-header/_site-header.scss
+++ b/src/legacy/components/site-header/_site-header.scss
@@ -82,7 +82,6 @@
 
     .site-branding--icon {
       background-image: svg-load('icons/mltshp-icon.svg');
-      display: block;
       height: 2em; // should match button height
       width: 2em;
     }

--- a/src/legacy/components/site-header/_site-header.scss
+++ b/src/legacy/components/site-header/_site-header.scss
@@ -82,9 +82,9 @@
 
     .site-branding--icon {
       background-image: svg-load('icons/mltshp-icon.svg');
-      display: inline-block;
-      height: 2.475em; // approximated this comparing to label mixin height
-      width: 2.475em;
+      display: block;
+      height: 2em; // should match button height
+      width: 2em;
     }
 
     .site-branding--logo {
@@ -113,5 +113,19 @@
 
   .site-header.docked & {
     margin-top: 0;
+  }
+}
+
+.site-nav .btn {
+  .site-header.docked & {
+    font-size: 16px;
+    height: 2em;
+    line-height: 2em;
+  }
+
+  &.btn-icon {
+    .site-header.docked & {
+      width: 2em;
+    }
   }
 }

--- a/src/legacy/components/site-header/examples/logged-in-with-content.html
+++ b/src/legacy/components/site-header/examples/logged-in-with-content.html
@@ -40,7 +40,7 @@
           src="https://mltshp-cdn.com/static/images/logo-compact.svg"
           alt="MLTSHP"
         />
-        <div class="site-branding--icon" />
+        <div class="site-branding--icon"></div>
       </div>
       <nav id="site-nav" class="site-nav">
         <a

--- a/src/legacy/components/site-header/examples/logged-in-with-content.html
+++ b/src/legacy/components/site-header/examples/logged-in-with-content.html
@@ -39,7 +39,8 @@
           class="site-branding--logo"
           src="https://mltshp-cdn.com/static/images/logo-compact.svg"
           alt="MLTSHP"
-        /><span class="site-branding--icon" />
+        />
+        <div class="site-branding--icon" />
       </div>
       <nav id="site-nav" class="site-nav">
         <a

--- a/src/legacy/components/site-header/examples/logged-in-with-content.html
+++ b/src/legacy/components/site-header/examples/logged-in-with-content.html
@@ -40,7 +40,7 @@
           src="https://mltshp-cdn.com/static/images/logo-compact.svg"
           alt="MLTSHP"
         />
-        <div class="site-branding--icon"></div>
+        <div class="site-branding--icon" aria-label="MLTSHP"></div>
       </div>
       <nav id="site-nav" class="site-nav">
         <a


### PR DESCRIPTION
## Overview

This PR reduces the size of the peekaboo header from 60px to 48px, to give it a bit less prominence.

## Screenshots

**Old:**
<img width="806" alt="Screenshot 2025-02-28 at 2 22 05 PM" src="https://github.com/user-attachments/assets/02af2cfa-1380-4cc5-8438-78a7307e7d29" />
<img width="416" alt="Screenshot 2025-02-28 at 2 22 15 PM" src="https://github.com/user-attachments/assets/3dfb5204-fbdc-4801-8b64-7a7653c27472" />

**New:**
<img width="808" alt="Screenshot 2025-02-28 at 2 22 34 PM" src="https://github.com/user-attachments/assets/7c42dfaf-d543-4e05-9c47-77d551b28160" />
<img width="414" alt="Screenshot 2025-02-28 at 2 22 46 PM" src="https://github.com/user-attachments/assets/ec314ff8-eb70-46f9-8799-8bc2cf093e63" />

## Testing

On the preview deploy, review the [Legacy > Components > Site Header > Logged In With Content story](https://deploy-preview-1331--mltshp-patterns.netlify.app/iframe.html?args=&id=legacy-components-site-header--logged-in-with-content&viewMode=story) on large and small screens.

---

- Fixes #1327
