### PR TITLE
Bugfix: Site Nav Callout Text Should Wrap

### DIFF
--- a/src/components/site-header/examples/logged-out.html
+++ b/src/components/site-header/examples/logged-out.html
@@ -26,6 +26,9 @@ iframe: true
 						<a class="btn btn-warning btn-pastel" href="#">Popular</a>
 					</li>
 					<li class="site-nav--item site-nav--signup">
+						<div class="call-out">
+							Join us! Sign up to post images and create your own shake.
+						</div>
 						<a class="btn btn-primary btn-shadow" href="#">Sign Up!</a>
 					</li>
 				</ul>

--- a/src/components/site-nav/_site-nav.scss
+++ b/src/components/site-nav/_site-nav.scss
@@ -87,6 +87,7 @@
 	max-width: 18em;
 	padding-right: var(--size-spacing-default);
 	padding-top: 3px;
+	text-wrap: auto;
 
 	@media screen and (min-width: tokens.$size-breakpoint-lg) {
 		display: block;


### PR DESCRIPTION
## Overview

This PR fixes a bug where the text in the logged-out Site Nav callout was not wrapping, causing the layout to look broken.

## Screenshots

<img width="886" alt="Screenshot 2025-06-20 at 4 40 25 PM" src="https://github.com/user-attachments/assets/a3fe4fec-54f5-44a6-8381-be9d99240d46" />

## Testing

- [ ] View the [Site Header](https://deploy-preview-1381--mltshp-patterns.netlify.app/components/site-header/) logged out example on the preview deploy
- [ ] The callout text (next to the Sign Up button) should wrap

---

- Fixes #1333
