### PR TITLE
Added a tab order friendly hide and show mechanism for comment reply-to and delete controls

### DIFF
--- a/src/components/image-comments/_image-comments.scss
+++ b/src/components/image-comments/_image-comments.scss
@@ -54,6 +54,13 @@
 				margin-left: 0.825em;
 			}
 
+			// Override margin applied to all meta children above. Otherwise the form
+			// can affect position of the delete control.
+			.delete-form {
+				width: 0;
+				margin: 0;
+			}
+
 			.username,
 			.user-name {
 				font-size: 0.875rem;
@@ -64,44 +71,12 @@
 				margin-left: 0.25em;
 			}
 
-			.reply-to {
-				background-image: svg-load('icons/reply.svg');
-				background-position: 0 0;
-				background-repeat: no-repeat;
-				background-size: 12px 11px;
-				display: none;
-				padding-left: var(--size-spacing-half-again);
-			}
-
-			.delete {
-				background-image: svg-load('icons/delete-comment.svg');
-				background-position: 0 0;
-				background-repeat: no-repeat;
-				background-size: 13px 13px;
-				display: none;
-				padding-left: var(--size-spacing-half-again);
-			}
-
 			.created-at {
 				color: var(--color-page-text-secondary);
 			}
-		}
 
-		&:hover,
-		&:focus {
-			.meta {
-				.reply-to {
-					display: inline;
-				}
-
-				form {
-					display: none;
-				}
-
-				.delete {
-					display: inline;
-				}
-			}
+			// reply-to and delete controls defined further up the tree to enable
+			// reuse.
 		}
 	}
 }

--- a/src/components/image-comments/examples/image-comment.html
+++ b/src/components/image-comments/examples/image-comment.html
@@ -36,6 +36,7 @@
 					>
 				</span>
 				<a class="reply-to" href="">Reply</a>
+				<form class="delete-form"></form>
 				<a href="" class="delete link--danger">Delete</a>
 			</div>
 			<div class="comment-body-text">

--- a/src/components/images/_images.scss
+++ b/src/components/images/_images.scss
@@ -10,3 +10,47 @@
 @use 'partials/image-interactions';
 @use 'partials/image-footer';
 @use 'partials/image-comments';
+
+// Styles used by both image-content and image-comments to hide reply-to and
+// delete controls on comments by default. These controls become visible when
+// the user hovers over the parent comment, or the parent comment or the
+// reply-to or delete controls get focus (say, through the tab order).
+.image-content,
+.image-comments {
+	.comment {
+		// Styles common to both controls. Set opacity to 0 to hide in place by
+		// default, and add a little easing to fade in and out less jarringly.
+		.reply-to,
+		.delete {
+			background-position: 0 0;
+			background-repeat: no-repeat;
+			opacity: 0;
+			transition: opacity 0.2s ease;
+			padding-left: var(--size-spacing-half-again);
+		}
+
+		// Control specific styles.
+		.reply-to {
+			background-image: svg-load('icons/reply.svg');
+			background-size: 12px 11px;
+		}
+		.delete {
+			background-image: svg-load('icons/delete-comment.svg');
+			background-size: 13px 13px;
+		}
+
+		// Make visible if containing comment receives focus ...
+		&:hover .reply-to,
+		&:hover .delete,
+		&:focus .reply-to,
+		&:focus .delete {
+			opacity: 1;
+		}
+
+		// ... or if control itself receives focus via tabbing.
+		.reply-to:focus,
+		.delete:focus {
+			opacity: 1;
+		}
+	}
+}

--- a/src/components/images/partials/_image-comments.scss
+++ b/src/components/images/partials/_image-comments.scss
@@ -93,31 +93,8 @@
 				padding-top: 0;
 			}
 
-			.reply-to {
-				background-image: svg-load('icons/reply.svg');
-				background-position: 0 0;
-				background-repeat: no-repeat;
-				background-size: 12px 11px;
-				display: none;
-				padding-left: var(--size-spacing-half-again);
-			}
-
-			.delete {
-				@include links.link-danger;
-				background-image: svg-load('icons/delete-comment.svg');
-				background-position: 0 0;
-				background-repeat: no-repeat;
-				background-size: 13px 13px;
-				display: none;
-				padding-left: var(--size-spacing-half-again);
-			}
-
-			&:hover .reply-to,
-			&:hover .delete,
-			&:focus .reply-to,
-			&:focus .delete {
-				display: block;
-			}
+			// reply-to and delete controls defined further up the tree to enable
+			// reuse.
 		}
 
 		.show-more-comments {


### PR DESCRIPTION

## Overview

Added a hide and show mechanism for comment reply-to and delete controls that also lets them remain in the tab order. Better for accessibility.

## Screenshots

https://github.com/user-attachments/assets/21a9d9ad-e6bb-4537-b846-9f01f2ada6f0

## Testing

1. Hover mouse over comment on desktop, and touch comment on mobile, to regression test. Both reply-to and delete (if relevant) should appear as they always have.
2. Use tab key on desktop to tab through components. When reaching reply-to and delete controls they should fade in and out as they get focus.
3. Replying to and deleting with mouse click should work as they always have on desktop. Pressing the enter key when targeted via tabbing should have the same effect as clicking with the mouse on each control.

---

- Fixes #244
