### PR TITLE
Removed scaling down of paragraph text blocks in several areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a tab order friendly hide and show mechanism for comment reply-to and
   delete controls (#1396)
+- Removed scaling down of paragraph text blocks in several areas to make prose text more readable (#1406)
 
 ## [4.0.0] - 2025-06-21
 

--- a/src/areas/faq/_faq.scss
+++ b/src/areas/faq/_faq.scss
@@ -20,8 +20,8 @@
 
 	/* Space out the list items a little. */
 	li {
-		margin-top: var(--size-spacing-default);
 		margin-bottom: var(--size-spacing-default);
+		margin-top: var(--size-spacing-default);
 	}
 
 	/* Use solid disk for nested lists */

--- a/src/areas/faq/_faq.scss
+++ b/src/areas/faq/_faq.scss
@@ -1,4 +1,3 @@
-// These styles are mostly just overriding `.content-narrow p` rules.
 @use '../../base/links';
 
 .faq-page {
@@ -11,16 +10,22 @@
 		margin-top: var(--size-spacing-half-again);
 	}
 
-	// override `.content-narrow p`
 	p,
 	li {
-		font-size: 0.875rem;
-		line-height: 2;
-		margin-top: 5px;
-
 		a {
 			@include links.link-primary;
 			@include links.link-emphasized;
 		}
+	}
+
+	/* Space out the list items a little. */
+	li {
+		margin-top: var(--size-spacing-default);
+		margin-bottom: var(--size-spacing-default);
+	}
+
+	/* Use solid disk for nested lists */
+	ul ul {
+		list-style-type: disc;
 	}
 }

--- a/src/areas/incoming/_incoming.scss
+++ b/src/areas/incoming/_incoming.scss
@@ -18,7 +18,6 @@
 
 		p {
 			color: var(--color-page-text-secondary);
-			font-size: 0.875rem;
 			margin: 0;
 		}
 	}

--- a/src/areas/legal/_legal.scss
+++ b/src/areas/legal/_legal.scss
@@ -1,5 +1,3 @@
-// These styles are mostly just overriding `.content-narrow p` rules.
-
 //
 // Code of Conduct Page
 //
@@ -14,12 +12,6 @@
 		margin-top: 1.4em;
 	}
 
-	p {
-		font-size: 1rem;
-		line-height: 1.4;
-		margin: 1em 0;
-	}
-
 	li {
 		margin-bottom: 0.4em;
 	}
@@ -29,12 +21,6 @@
 // Terms of Use Page
 //
 .terms-of-use {
-	p {
-		font-size: 1rem;
-		line-height: 1.4;
-		margin: 1em 0;
-	}
-
 	li {
 		font-size: 1rem;
 		list-style-type: lower-alpha;
@@ -49,10 +35,3 @@
 //
 // Terms of Use Announcement Page
 //
-.tou-notice-page {
-	p {
-		font-size: 1rem;
-		line-height: 1.4;
-		margin: 1em 0;
-	}
-}

--- a/src/areas/settings/_settings.scss
+++ b/src/areas/settings/_settings.scss
@@ -147,7 +147,6 @@
 	.member-status-block-content {
 		background-color: var(--color-background-content);
 		border-radius: var(--size-border-radius-large);
-		font-size: 0.875rem;
 		margin-top: var(--size-spacing-default);
 		padding: var(--size-spacing-double);
 	}
@@ -240,7 +239,6 @@
 		}
 
 		p {
-			font-size: 0.875rem;
 			margin-bottom: 0;
 		}
 	}

--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -11,7 +11,7 @@ html {
 	font-size: var(--size-font-base);
 	font-weight: var(--number-font-weight-normal);
 	letter-spacing: var(--letter-spacing);
-	line-height: 1.3;
+	line-height: 1.4;
 }
 
 h1,

--- a/src/components/conversations/_conversations.scss
+++ b/src/components/conversations/_conversations.scss
@@ -70,8 +70,6 @@
 
 	.sharedfile-description {
 		@include mixins.breakword;
-		font-size: 0.875rem;
-		line-height: 1.3;
 		overflow: hidden;
 	}
 

--- a/src/components/features/_features.scss
+++ b/src/components/features/_features.scss
@@ -100,8 +100,6 @@
 
 .feature--body {
 	color: var(--color-page-text);
-	font-size: 0.875rem;
-	line-height: 1.25;
 	margin: var(--size-spacing-default) 0 0;
 
 	p {

--- a/src/components/forms/_forms.scss
+++ b/src/components/forms/_forms.scss
@@ -81,7 +81,6 @@ textarea {
 	// help text
 	.field-help {
 		color: var(--color-page-text-secondary);
-		font-size: 0.875rem;
 		margin-top: var(--size-spacing-half);
 
 		@media screen and (min-width: tokens.$size-breakpoint-lg) {

--- a/src/components/image-comments/_image-comments.scss
+++ b/src/components/image-comments/_image-comments.scss
@@ -28,13 +28,11 @@
 
 		.body {
 			flex: 1;
-			font-size: 0.875rem;
-			line-height: 1.3;
 			overflow: hidden;
 
 			.where-from {
 				color: var(--color-page-text-secondary);
-				font-size: 0.825em;
+				font-size: 0.75rem;
 				padding-top: var(--size-spacing-default);
 			}
 		}
@@ -47,7 +45,7 @@
 			align-items: flex-end;
 			display: flex;
 			flex-wrap: wrap;
-			font-size: 0.825em;
+			font-size: 0.75rem;
 			padding-bottom: var(--size-spacing-default);
 
 			> * + * {

--- a/src/components/images/partials/_image-comments.scss
+++ b/src/components/images/partials/_image-comments.scss
@@ -62,14 +62,16 @@
 				@include mixins.breakword;
 				clear: both;
 				color: var(--color-page-text);
-				font-size: 0.875rem;
-				padding-top: 0.25em;
 			}
 
 			.meta {
 				align-items: flex-end;
 				display: flex;
 				flex-wrap: wrap;
+
+				font-size: 0.75rem;
+
+				margin-bottom: 0.4rem;
 
 				> * + * {
 					margin-left: 0.8em;
@@ -99,6 +101,7 @@
 
 		.show-more-comments {
 			display: block;
+			font-size: 0.75rem;
 			font-weight: var(--number-font-weight-bold);
 			padding: var(--size-spacing-default) 0;
 			text-align: right;

--- a/src/components/images/partials/_image-comments.scss
+++ b/src/components/images/partials/_image-comments.scss
@@ -68,9 +68,7 @@
 				align-items: flex-end;
 				display: flex;
 				flex-wrap: wrap;
-
 				font-size: 0.75rem;
-
 				margin-bottom: 0.4rem;
 
 				> * + * {

--- a/src/components/images/partials/_image-description.scss
+++ b/src/components/images/partials/_image-description.scss
@@ -4,7 +4,6 @@
 .image-content {
 	.description {
 		color: var(--color-page-text);
-		font-size: 0.875rem;
 		overflow: hidden;
 		padding-bottom: var(--size-spacing-default);
 	}

--- a/src/components/images/partials/_image-footer.scss
+++ b/src/components/images/partials/_image-footer.scss
@@ -1,6 +1,5 @@
 .image-content-footer {
 	color: var(--color-page-text-secondary);
-	font-size: 0.75rem;
 	padding-top: var(--size-spacing-default);
 
 	.originally-posted-by {
@@ -22,6 +21,7 @@
 	.inline-meta {
 		display: flex;
 		float: left;
+		font-size: 0.75rem;
 
 		> * {
 			flex: none;

--- a/src/components/images/partials/_image-footer.scss
+++ b/src/components/images/partials/_image-footer.scss
@@ -28,6 +28,10 @@
 		}
 	}
 
+	.save-this-shake-selector {
+		font-size: 0.75rem;
+	}
+
 	.created-at {
 		padding-top: var(--size-spacing-half);
 

--- a/src/components/new-user-dashboard/_new-user-dashboard.scss
+++ b/src/components/new-user-dashboard/_new-user-dashboard.scss
@@ -20,13 +20,10 @@
 	}
 
 	h4 {
-		font-size: 0.875rem;
 		margin-bottom: var(--size-spacing-half);
 	}
 
 	p {
-		font-size: 0.875rem;
-		line-height: 1.75;
 		padding-bottom: var(--size-spacing-half-again);
 	}
 

--- a/src/components/sidebar/_sidebar.scss
+++ b/src/components/sidebar/_sidebar.scss
@@ -119,7 +119,6 @@
 .find-shakes-block-content {
 	background-color: var(--color-background-content);
 	border-radius: var(--size-border-radius-large);
-	font-size: 0.875rem;
 	margin-top: var(--size-spacing-default);
 	padding: var(--size-spacing-double);
 
@@ -146,7 +145,6 @@
 .upgrade-account-block-content {
 	background-color: var(--color-background-content);
 	border-radius: var(--size-border-radius-large);
-	font-size: 0.875rem;
 	margin-top: var(--size-spacing-half);
 	padding: var(--size-spacing-double);
 
@@ -179,7 +177,6 @@
 	}
 
 	p {
-		font-size: 0.875rem;
 		margin: var(--size-spacing-half) 0 0;
 	}
 
@@ -192,7 +189,7 @@
 		background-size: 40px 45px;
 		border-radius: var(--size-border-radius-large);
 		display: block;
-		font-size: 0.75rem;
+		font-size: 0.875rem;
 		padding: var(--size-spacing-default);
 		padding-bottom: var(--size-spacing-double);
 		padding-left: 55px;

--- a/src/components/site-footer/_site-footer.scss
+++ b/src/components/site-footer/_site-footer.scss
@@ -1,6 +1,5 @@
 .site-footer {
 	color: var(--color-page-text-secondary);
-	font-size: 0.75em;
 	margin: var(--size-spacing-triple);
 	text-align: center;
 
@@ -10,9 +9,5 @@
 		+ p {
 			margin-top: 0.5em;
 		}
-	}
-
-	a {
-		white-space: nowrap;
 	}
 }

--- a/src/layout/_page.scss
+++ b/src/layout/_page.scss
@@ -39,19 +39,12 @@
 // Single-Column Layout
 //
 .content-narrow {
-	margin: var(--size-spacing-quadruple) auto var(--size-spacing-triple);
+	margin: var(--size-spacing-half-again) auto var(--size-spacing-triple);
 	max-width: 700px;
 	padding: var(--size-spacing-half-again);
 
 	@media screen and (min-width: tokens.$size-breakpoint-lg) {
 		padding: var(--size-spacing-quadruple);
-	}
-
-	// I hate this. We spend more time overriding it. -SV
-	p {
-		font-size: 1.625rem; // 26px
-		line-height: 2.5;
-		margin: 2em 0;
 	}
 
 	.extra-info p {


### PR DESCRIPTION
## Overview

Removed quite a few font-size definitions that slightly scaled down paragraph text. This should increase font size in most long form contexts making them easier to read, esp on mobile.

Won't affect heading sizes or layout beyond making pages a bit longer. Have left meta data text and text in sparsely laid out lists (think "Cool tools" or "In these shakes") unchanged for the time being.

Also removed the troublesome `.narrow-context p` styles.

## Screenshots

Before and afters of a few places.

<img width="1014" height="664" alt="p-font-size-3" src="https://github.com/user-attachments/assets/97563cc4-ea8e-4dbe-85cc-7ef260855d26" />

<img width="876" height="691" alt="p-font-size-2" src="https://github.com/user-attachments/assets/5fab5e07-98fe-4f15-a395-2601ad46512e" />

<img width="585" height="658" alt="p-font-size-1" src="https://github.com/user-attachments/assets/39d3fbd1-4b85-4515-8dfb-230576d4fdcf" />

Also (as a side effect of removing `.narrow-context p`) the [Terms of use](https://web.archive.org/web/20250702022816/https://mltshp.com/terms-of-use) page seems to speak in a more measured tone.

## Testing

1. Fairly minor change, though keep an eye out for non-user driven content areas like buttons, sidebars or menus misbehaving due to the larger paragraph text.
2. Modified the base line-height marginally, so have tested on Chromium and Webkit browsers on mac.  The paragraphs look good there, though would be good to have some eyes on Windows and Android as well.

---

- Fixes #209
- Fixes #1398
