### PR TITLE
Tweaked user counts section formatting

### DIFF
--- a/src/base/examples/text-semantics.html
+++ b/src/base/examples/text-semantics.html
@@ -19,8 +19,8 @@
 	The <small>small element</small> example <br />
 	The <span>span element</span> example <br />
 	The <strong>strong element</strong> example <br />
-	The <sub>sub element</sub> example <br />
 	The <sup>sup element</sup> example <br />
+	The <sub>sub element</sub> example <br />
 	The <var>var element</var> example <br />
 	The <u>u element</u> example
 </p>

--- a/src/components/user-counts/_user-counts.scss
+++ b/src/components/user-counts/_user-counts.scss
@@ -27,16 +27,14 @@
 			display: block;
 			font-size: 1.125rem;
 			font-weight: var(--number-font-weight-bold);
+			color: inherit;
+			text-decoration-color: inherit;
 		}
 
 		.label {
 			display: block;
 			font-size: 0.875rem;
 		}
-	}
-
-	.views {
-		width: 95px; // magic number to give views more space than other cells
 	}
 
 	.saves {

--- a/src/components/user-counts/examples/user-counts-narrow.html
+++ b/src/components/user-counts/examples/user-counts-narrow.html
@@ -2,15 +2,15 @@
 	<div name="username" class="user-counts">
 		<ul>
 			<li class="views">
-				<span class="num">7,438,959</span>
+				<span class="num">7.4M</span>
 				<span class="label-text">Views</span>
 			</li>
 			<li class="saves">
-				<span class="num">22,511</span>
+				<span class="num">22.5K</span>
 				<span class="label-text">Saves</span>
 			</li>
 			<li class="likes">
-				<span class="num">140,205</span>
+				<a class="num" href="#">140.2K</a>
 				<span class="label-text">Likes</span>
 			</li>
 		</ul>

--- a/src/components/user-counts/examples/user-counts.html
+++ b/src/components/user-counts/examples/user-counts.html
@@ -1,7 +1,7 @@
 <div name="username" class="user-counts">
 	<ul>
 		<li class="views">
-			<span class="num">24,853</span>
+			<span class="num">24.8K</span>
 			<span class="label-text">Views</span>
 		</li>
 		<li class="saves">
@@ -9,7 +9,7 @@
 			<span class="label-text">Saves</span>
 		</li>
 		<li class="likes">
-			<span class="num">374</span>
+			<a class="num" href="#">374</a>
 			<span class="label-text">Likes</span>
 		</li>
 	</ul>


### PR DESCRIPTION
## Overview

- Update patterns example markup to match what's in prod
- Now that [Display massive user statistic numbers more compactly](https://github.com/MLTSHP/mltshp/pull/853) is live, remove the extra space given the the views panel
- Color the link text of a user's likes red to match the rest of that panel
- Unrelated tweak while we're here to reorder `<sub>` and `<sup>` examples on typography page

## Screenshots

Stats panel
<img  height="100" alt="image1" src="https://github.com/user-attachments/assets/a479fa8d-bd39-414c-8309-33031d03a4ce" />

Sup and sub example

<img  height="100" alt="image1-0" src="https://github.com/user-attachments/assets/48acbd03-d50f-4002-a054-192aaf6df2a5" />

---

- Fixes #1407 
